### PR TITLE
symlink entire emulator config dir

### DIFF
--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -77,8 +77,9 @@ modules:
       - ln -s /var/data/logs/fcade.log.1 emulator/fcade.log.1
       - ln -s /var/data/logs/fcade.log.2 emulator/fcade.log.3
       - ln -s /var/data/logs/fcade.log.3 emulator/fcade.log.2
-      # Symlink FBNeo config to writable file
-      - ln -s /var/data/config/fcadefbneo.ini emulator/fbneo/config/fcadefbneo.ini
+      # Symlink emulator configs to writable directories
+      - rm -rf emulator/fbneo/config
+      - ln -s /var/data/config/fcadefbneo emulator/fbneo/config
       # Wine wrapper
       - install -Dm755 wine.sh /app/fightcade/Resources/wine.sh
       - cp -R * /app/fightcade/Fightcade

--- a/scripts/fightcade-launcher.sh
+++ b/scripts/fightcade-launcher.sh
@@ -22,8 +22,8 @@ mkdir -p ${DATADIR}/ROMs/ggpofba
 mkdir -p ${DATADIR}/ROMs/snes9x
 
 # Emulator config directory
-mkdir -p ${DATADIR}/config
-cp -n /app/fightcade/Fightcade/emulator/fbneo/config/fcadefbneo.default.ini ${DATADIR}/config/fcadefbneo.ini
+mkdir -p ${DATADIR}/config/fcadefbneo
+cp -n /app/fightcade/Fightcade/emulator/fbneo/config/fcadefbneo.default.ini ${DATADIR}/config/fcadefbneo/fcadefbneo.ini
 
 # Boot Fightcade frontend
 /app/bin/zypak-wrapper /app/fightcade/Fightcade/fc2-electron/fc2-electron


### PR DESCRIPTION
This should fix a problem with game-specific input mappings not
persisting between sessions.

Resolves https://github.com/flathub/com.fightcade.Fightcade/issues/4