### PR TITLE
Stable release 2.0.82-1

### DIFF
--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -71,9 +71,6 @@ modules:
       - ln -s /var/data/ROMs/ggpofba emulator/ggpofba/ROMs
       - rmdir emulator/snes9x/ROMs
       - ln -s /var/data/ROMs/snes9x emulator/snes9x/ROMs
-      # Update Fightcade's builtin ROMs dir
-      - rm -rf ROMs/
-      - ln -s /var/data/ROMs ROMs
       # Log files Fightcade expects to be able to write to
       - ln -s /logs/fcade-errors.log emulator/fcade-errors.log
       - ln -s /var/data/logs/fcade.log emulator/fcade.log
@@ -99,6 +96,9 @@ modules:
         dest-filename: wine.sh
         commands:
           - /app/bin/wine "$@"
+      # Temporary patch to open XDG_DATA_HOME/ROMs from GUI
+      - type: patch
+        path: fightcade-flatpak-romsdir.patch
 
   - name: fightcade-extra
     buildsystem: simple

--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -77,8 +77,9 @@ modules:
       - ln -s /var/data/logs/fcade.log.1 emulator/fcade.log.1
       - ln -s /var/data/logs/fcade.log.2 emulator/fcade.log.3
       - ln -s /var/data/logs/fcade.log.3 emulator/fcade.log.2
-      # Symlink FBNeo config to writable file
-      - ln -s /var/data/config/fcadefbneo.ini emulator/fbneo/config/fcadefbneo.ini
+      # Symlink emulator configs to writable directories
+      - rm -rf emulator/fbneo/config
+      - ln -s /var/data/config/fcadefbneo emulator/fbneo/config
       # Wine wrapper
       - install -Dm755 wine.sh /app/fightcade/Resources/wine.sh
       - cp -R * /app/fightcade/Fightcade

--- a/fightcade-flatpak-romsdir.patch
+++ b/fightcade-flatpak-romsdir.patch
@@ -1,0 +1,17 @@
+--- Fightcade/fc2-electron/resources/app/lib/main.js	2020-07-27 09:05:52.000000000 -0400
++++ main.js	2020-09-29 10:19:37.687986200 -0400
+@@ -8824,7 +8824,13 @@
+                         electron_1.shell.openPath(path.dirname(process.execPath)+'\\..\\ROMs');
+                     }
+                     if (helpers_1.isLinux()) {
+-                        electron_1.shell.openPath(path.dirname(process.execPath)+'/../ROMs');
++                        fs.stat('/.flatpak-info', (error, stats) => {
++                            if (error) {
++                                electron_1.shell.openPath(path.dirname(process.execPath)+'/../ROMs');
++                            } else {
++                                electron_1.shell.openPath(path.join(process.env['XDG_DATA_HOME'], 'ROMs'));
++                            }
++                        });
+                     }
+                 },
+             },

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -28,7 +28,7 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release date="2020-10-04" version="2.8.0-1">
+    <release date="2020-10-04" version="2.0.82-1">
       <p>Small improvements to Flatpak integration</p>
       <ul>
         <li>
@@ -40,7 +40,7 @@
         </li>
       </ul>
     </release>
-    <release date="2020-09-10" version="2.8.0"/>
+    <release date="2020-09-10" version="2.0.82"/>
   </releases>
   <content_rating type="oars-1.1">
     <content_attribute id="violence-cartoon">intense</content_attribute>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -28,6 +28,18 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release date="2020-10-04" version="2.8.0-1">
+      <p>Small improvements to Flatpak integration</p>
+      <ul>
+        <li>
+          Patches the Electron frontend to fix 'Open ROMs Dir'
+          <i>(Note: due to an upstream bug this doesn't work on xdg-desktop 1.8.0~1.8.2)</i>
+        </li>
+        <li>
+          Fix FBNeo configs not persisting between emulator sessions
+        </li>
+      </ul>
+    </release>
     <release date="2020-09-10" version="2.8.0"/>
   </releases>
   <content_rating type="oars-1.1">

--- a/scripts/fightcade-launcher.sh
+++ b/scripts/fightcade-launcher.sh
@@ -22,8 +22,8 @@ mkdir -p ${DATADIR}/ROMs/ggpofba
 mkdir -p ${DATADIR}/ROMs/snes9x
 
 # Emulator config directory
-mkdir -p ${DATADIR}/config
-cp -n /app/fightcade/Fightcade/emulator/fbneo/config/fcadefbneo.default.ini ${DATADIR}/config/fcadefbneo.ini
+mkdir -p ${DATADIR}/config/fcadefbneo
+cp -n /app/fightcade/Fightcade/emulator/fbneo/config/fcadefbneo.default.ini ${DATADIR}/config/fcadefbneo/fcadefbneo.ini
 
 # Boot Fightcade frontend
 /app/bin/zypak-wrapper /app/fightcade/Fightcade/fc2-electron/fc2-electron


### PR DESCRIPTION
Small improvements to Flatpak integration
* Patches the Electron frontend to fix 'Open ROMs Dir' (Note: due to an upstream bug this doesn't work on xdg-desktop 1.8.0~1.8.2)
* Fix FBNeo configs not persisting between emulator sessions