### PR TITLE
Initial Snes9x support

### DIFF
--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -84,6 +84,11 @@ modules:
       # Symlink emulator configs to writable directories
       - rm -rf emulator/fbneo/config
       - ln -s /var/data/config/fcadefbneo emulator/fbneo/config
+      - ln -s /var/data/config/snes9x/fcadesnes9x.conf emulator/snes9x/fcadesnes9x.conf
+      # Snes9x fix
+      - ln -s /var/data/config/snes9x/Valid.Ext emulator/snes9x/Valid.Ext
+      - ln -s /var/data/config/snes9x/stdout.txt emulator/snes9x/stdout.txt
+      - ln -s /var/data/config/snes9x/stderr.txt emulator/snes9x/stderr.txt
       # Wine wrapper
       - install -Dm755 wine.sh /app/fightcade/Resources/wine.sh
       - cp -R * /app/fightcade/Fightcade

--- a/scripts/fightcade-launcher.sh
+++ b/scripts/fightcade-launcher.sh
@@ -18,9 +18,16 @@ mkdir -p ${DATADIR}/ROMs/fbneo
 mkdir -p ${DATADIR}/ROMs/ggpofba
 mkdir -p ${DATADIR}/ROMs/snes9x
 
-# Emulator config directory
+# Emulator config directories
+# FBNeo
 mkdir -p ${DATADIR}/config/fcadefbneo
 cp -n /app/fightcade/Fightcade/emulator/fbneo/config/fcadefbneo.default.ini ${DATADIR}/config/fcadefbneo/fcadefbneo.ini
+# Snes9x
+mkdir -p ${DATADIR}/config/snes9x
+cp -n /app/fightcade/Fightcade/emulator/snes9x/fcadesnes9x.default.conf ${DATADIR}/config/snes9x/fcadesnes9x.conf
+touch ${DATADIR}/config/snes9x/Valid.Ext
+touch ${DATADIR}/config/snes9x/stdout.txt
+touch ${DATADIR}/config/snes9x/stderr.txt
 
 # Boot Fightcade frontend
 /app/bin/zypak-wrapper /app/fightcade/Fightcade/fc2-electron/fc2-electron


### PR DESCRIPTION
Implement a workaround for Valid.Ext not existing as well as add a
symlink for the Snes9x configuration file.