### PR TITLE
snes9x: fix early crash

### DIFF
--- a/scripts/fightcade-launcher.sh
+++ b/scripts/fightcade-launcher.sh
@@ -32,7 +32,7 @@ cp -n /app/fightcade/Fightcade/emulator/fbneo/config/fcadefbneo.default.ini ${DA
 mkdir -p ${DATADIR}/config/snes9x
 mkdir -p ${DATADIR}/config/snes9x/Saves
 cp -n /app/fightcade/Fightcade/emulator/snes9x/fcadesnes9x.default.conf ${DATADIR}/config/snes9x/fcadesnes9x.conf
-touch ${DATADIR}/config/snes9x/Valid.Ext
+echo "N" > ${DATADIR}/config/snes9x/Valid.Ext
 touch ${DATADIR}/config/snes9x/stdout.txt
 touch ${DATADIR}/config/snes9x/stderr.txt
 


### PR DESCRIPTION
Put an 'N' into Valid.Ext to stop Snes9x from crashing

For some reason Snes9x requires the Valid.Ext file to not be empty to
not crash, putting an 'N' in it gets past the initial crash and allows
the emulator to load.