### PR TITLE
flycast: add libzip 1.7.3 dependency

### DIFF
--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -131,6 +131,22 @@ modules:
       - type: file
         path: metainfo.xml
 
+  - name: libzip
+    buildsystem: cmake-ninja
+    config-opts:
+    - "-DCMAKE_BUILD_TYPE=Release"
+    - "-DCMAKE_INSTALL_LIBDIR=lib"
+    cleanup:
+    - "/include"
+    - "/bin"
+    - "/share"
+    - "/lib/pkgconfig"
+    - "/lib/*.la"
+    sources:
+    - type: archive
+      url: https://libzip.org/download/libzip-1.7.3.tar.xz
+      sha256: a60473ffdb7b4260c08bfa19c2ccea0438edac11193c3afbbb1f17fbcf6c6132
+
   - name: faudio32
     buildsystem: cmake-ninja
     build-options:

--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -113,6 +113,7 @@ modules:
       - install -Dm755 com.fightcade.Fightcade-128.png /app/share/icons/hicolor/128x128/apps/com.fightcade.Fightcade.png
       - install -Dm755 com.fightcade.Fightcade-256.png /app/share/icons/hicolor/256x256/apps/com.fightcade.Fightcade.png
       - install -Dm644 metainfo.xml /app/share/metainfo/com.fightcade.Fightcade.metainfo.xml
+      - ARCH_TRIPLE=$(gcc --print-multiarch) && ln -s /usr/lib/${ARCH_TRIPLE}/libcurl.so.4 /app/lib/libcurl-gnutls.so.4
     sources:
       - type: file
         path: com.fightcade.Fightcade.desktop


### PR DESCRIPTION
Flycast was changed to a native client in Fightcade v2.1.1, which
adds the additional dependency of libzip.