### PR TITLE
Flycast: add hack for BIOS files in r/o directory

### DIFF
--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -98,6 +98,8 @@ modules:
       # Flycast fixes
       - ln -s /var/data/config/flycast/emu.cfg emulator/flycast/emu.cfg
       - ln -s /var/data/config/flycast/mappings emulator/flycast/mappings
+      - ln -s /var/data/ROMs/flycast/awbios.zip emulator/flycast/data/awbios.zip 
+      - ln -s /var/data/ROMs/flycast/naomi.zip emulator/flycast/data/naomi.zip 
       # Wine wrapper
       - install -Dm755 wine.sh /app/fightcade/Resources/wine.sh
       - cp -R * /app/fightcade/Fightcade


### PR DESCRIPTION
Flycast expects both BIOS files (naomi.zip, awbios.zip) to be in
'flycast/data/' which is a read-only directory. Because this directory
isn't empty we cannot recreate and symlink out the entire dir (like we
do currently with ROMs dirs) without an overly complicated migration.

As a quick workaround this commit explicitly symlinks the BIOS files
from the data dir into the user-writable ROMs dir so that users can drop
the BIOS files into the Flycast ROMs dir.