### PR TITLE
cleanup versions and add 1.3 release notes

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -28,13 +28,19 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release date="2020-10-24" version="2.0.95"/>
-    <release date="2020-10-24" version="2.0.94"/>
-    <release date="2020-10-24" version="2.0.91"/>
-    <release date="2020-10-24" version="2.0.89"/>
-    <release date="2020-10-24" version="2.0.87"/>
-    <release date="2020-10-22" version="2.0.86"/>
-    <release date="2020-10-04" version="2.0.82-1">
+    <release date="2021-10-14" version="1.3">
+      <p>Flycast support and 21.08 deps</p>
+      <ul>
+        <li>
+          Added miniupnpc dependency for Flycast
+        </li>
+        <li>
+          Update Flatpak runtimes to 21.08
+        </li>
+      </ul>
+    </release>
+    <release date="2020-10-24" version="1.2"/>
+    <release date="2020-10-04" version="1.1">
       <p>Small improvements to Flatpak integration</p>
       <ul>
         <li>
@@ -46,7 +52,7 @@
         </li>
       </ul>
     </release>
-    <release date="2020-09-10" version="2.0.82"/>
+    <release date="2020-09-20" version="1"/>
   </releases>
   <content_rating type="oars-1.1">
     <content_attribute id="violence-cartoon">intense</content_attribute>


### PR DESCRIPTION
we used to track the Fightcade version but since there is no automated way to do this we should use our own version system.