### PR TITLE
Add libminiupnpc for Flycast with GGPO.

### DIFF
--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -153,6 +153,28 @@ modules:
     build-commands:
       - ARCH_TRIPLE=$(gcc --print-multiarch) && ln -s /usr/lib/${ARCH_TRIPLE}/libcurl.so.4
         /app/lib/libcurl-gnutls.so.4
+  
+  # It also needs libminiupnpc
+  - name: libminiupnpc
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DUPNPC_BUILD_SHARED=true
+      - -DUPNPC_BUILD_STATIC=false
+      - -DUPNPC_BUILD_TESTS=false
+      - -DUPNPC_BUILD_SAMPLE=false
+      - -DUPNPC_NO_INSTALL=true
+    # For some reason, CMake's install asks for files that do not exist.
+    # So instead we'll install only the parts we care about ourselves.
+    no-make-install: true
+    post-install:
+      - install -m0644 -t /app/lib libminiupnpc.so.2.2.3
+      - install -m0644 -t /app/lib libminiupnpc.so.17
+      - install -m0644 -t /app/lib libminiupnpc.so
+    sources:
+      - type: archive
+        url: http://miniupnp.free.fr/files/miniupnpc-2.2.3.tar.gz
+        sha256: dce41b4a4f08521c53a0ab163ad2007d18b5e1aa173ea5803bd47a1be3159c24
 
   - name: libzip
     buildsystem: cmake-ninja


### PR DESCRIPTION
Without this, Flycast just doesn't start at all.