### PR TITLE
Add wine extension points to com.fightcade.Fightcade

### DIFF
--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -31,6 +31,10 @@ add-extensions:
     download-if: active-gl-driver
     enable-if: active-gl-driver
 
+  com.fightcade.Fightcade.Wine:
+    directory: wine
+    version: stable
+
 # Support 32-bit at buildtime
 sdk-extensions:
   - org.freedesktop.Sdk.Compat.i386
@@ -52,11 +56,12 @@ finish-args:
   - --env=LD_LIBRARY_PATH=/app/lib:/app/lib32
 
 modules:
-  # Create 32-bit directories
+  # Create 32-bit and wine directories
   - name: compat
     buildsystem: simple
     build-commands:
       - mkdir -p /app/lib/i386-linux-gnu /app/lib/debug/lib/i386-linux-gnu
+      - install -d /app/wine
 
   - name: fightcade
     buildsystem: simple


### PR DESCRIPTION
These are needed to submit com.fightcade.Fightcade.Wine to Flathub to
get Wine into a separate Flatpak.