### PR TITLE
wine.sh: raise a zenity error window when wine can't be found

### DIFF
--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -116,13 +116,8 @@ modules:
           url: https://web.fightcade.com/download/update.json
           version-pattern: Fightcade-linux-v([\d.]+).tar.gz
           url-template: https://web.fightcade.com/download/Fightcade-linux-v${version}.tar.gz
-      - type: script
-        dest-filename: wine.sh
-        # Due to switching from 32-bit wine to WoW64, we need to create a 64 bit prefix.
-        # Rather than doing a migration we'll just move to a new ~/.wine64 prefix
-        commands:
-          - export WINEPREFIX=~/.wine64
-          - /app/wine/bin/wine "$@"
+      - type: file
+        path: scripts/wine.sh
 
   - name: fightcade-extra
     buildsystem: simple

--- a/scripts/wine.sh
+++ b/scripts/wine.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+WINEERROR=$(cat <<-END
+<i>/app/wine/bin/wine</i> is missing.
+
+<b>com.fightcade.Fightcade.Wine</b> is required to run FinalBurn and Snes9x games
+END
+)
+
+WINEPATH="/app/wine/bin/wine"
+export WINEPREFIX=~/.wine64
+
+if [[ -f $(WINEPATH) ]]; then
+	/app/wine/bin/wine "$@"
+else
+	zenity \
+	  --warning \
+	  --title "Flatpak extension required" \
+	  --text "${WINEERROR}"
+fi


### PR DESCRIPTION
Since wine is planning to be shipped in an extension soon we should throw a graphical error to let users know they are missing an extension when they attempt to run Windows emulators.

Because Fightcade runs Wine from `Resources/wine.sh` we should overload this to do a check on `/app/wine/bin/wine` to see if it exists.

This should have no effect on native games.