### PR TITLE
add LD path for wine faudio

### DIFF
--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -34,6 +34,8 @@ add-extensions:
   com.fightcade.Fightcade.Wine:
     directory: wine
     version: stable
+    add-ld-path: lib
+    add-ld-path: lib32
     no-autodownload: false
 
 # Support 32-bit at buildtime


### PR DESCRIPTION
wine needs to be able to find faudio in both /app/wine/lib and
/app/wine/lib32