### PR TITLE
Change wineprefix to /var/data/winepfx

### DIFF
--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -52,7 +52,6 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   - --device=all
   - --env=PATH=/app/bin:/usr/bin:/app/wine/bin
-  - --persist=.wine
   # Skip Gecko and Mono popups when creating Wine prefix
   - --env=WINEDLLOVERRIDES=mscoree,mshtml=
   # Support 32-bit runtime

--- a/scripts/fightcade-launcher.sh
+++ b/scripts/fightcade-launcher.sh
@@ -6,10 +6,10 @@ DATADIR=/var/data
 # On first boot it can seem like the application is silently hanging since
 # on slower systems creating the wine prefix can take upwards of 2
 # minutes (tested on a 2-core Silverblue VM)
-echo "Creating or updating wine prefix (~/.wine), this may take a minute..."
+echo "Creating or updating wine prefix (/var/data/winepfx), this may take a minute..."
 
 # Silently create/update Wine prefix
-WINEPREFIX=~/.wine WINEDEBUG=-all DISPLAY=:invalid wineboot -u
+WINEPREFIX=/var/data/winepfx WINEDEBUG=-all DISPLAY=:invalid wineboot -u
 
 # Log file Fightcade expects to be able to write to
 mkdir -p /var/data/logs

--- a/scripts/wine.sh
+++ b/scripts/wine.sh
@@ -8,7 +8,7 @@ END
 )
 
 WINEPATH="/app/wine/bin/wine"
-export WINEPREFIX=~/.wine
+export WINEPREFIX=/var/data/winepfx
 
 if [[ -f ${WINEPATH} ]]; then
 	/app/wine/bin/wine "$@"


### PR DESCRIPTION
Using ~/.wine as our wine prefix causes a conflict when uses override
with --filesystem=home which can result in wine not running if said wine
prefix is from a newer release of wine.

Move the wine prefix into /var/data to avoid clashing with anything from
the host OS when overriding.