### PR TITLE
Add support for FBNeo training mode

### DIFF
--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -116,6 +116,9 @@ modules:
       # FBNeo config
       - rm -rf emulator/fbneo/config
       - ln -s /var/data/config/fcadefbneo emulator/fbneo/config
+      # FBNeo training mode
+      - rm -rf emulator/fbneo/fbneo-training-mode
+      - ln -s /var/data/fbneo-training-mode emulator/fbneo/fbneo-training-mode
       # Snes9x config
       - ln -s /var/data/config/snes9x/fcadesnes9x.conf emulator/snes9x/fcadesnes9x.conf
       - rm -r emulator/snes9x/Saves

--- a/scripts/fightcade-launcher.sh
+++ b/scripts/fightcade-launcher.sh
@@ -29,6 +29,7 @@ mkdir -p ${DATADIR}/ROMs/flycast
 # FBNeo
 mkdir -p ${DATADIR}/config/fcadefbneo
 cp -n /app/fightcade/Fightcade/emulator/fbneo/config/fcadefbneo.default.ini ${DATADIR}/config/fcadefbneo/fcadefbneo.ini 2> /dev/null
+mkdir -p ${DATADIR}/fbneo-training-mode
 # Snes9x
 mkdir -p ${DATADIR}/config/snes9x
 mkdir -p ${DATADIR}/config/snes9x/Saves


### PR DESCRIPTION
FBNeo needs write access to `emulators/fbneo/fbneo-training-mode/` for training modes in lobbies to function.

Resolves #95 