### PR TITLE
flathub.json: remove publish delay

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,4 @@
 {
   "only-arches": ["x86_64"],
-  "automerge-flathubbot-prs": true,
-  "publish-delay-hours": 0
+  "automerge-flathubbot-prs": true
 }


### PR DESCRIPTION
According to https://github.com/flathub/flatpak-builder-lint/issues/28 the modified publish delay option in Flathub.json is deprecated and no longer meant be used.