### PR TITLE
22.08 runtime update

### DIFF
--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -218,6 +218,11 @@ modules:
         url: https://libzip.org/download/libzip-1.9.2.tar.xz
         sha256: c93e9852b7b2dc931197831438fee5295976ee0ba24f8524a8907be5c2ba5937
 
+  - name: libzip symlink
+    buildsystem: simple
+    build-commands:
+      - ln -s /app/lib/libzip.so.5 /app/lib/libzip.so.4
+
   # Flycast native dep
   - name: libminiupnpc
     buildsystem: cmake-ninja

--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -215,8 +215,8 @@ modules:
       - /lib/*.la
     sources:
       - type: archive
-        url: https://libzip.org/download/libzip-1.7.3.tar.xz
-        sha256: a60473ffdb7b4260c08bfa19c2ccea0438edac11193c3afbbb1f17fbcf6c6132
+        url: https://libzip.org/download/libzip-1.9.2.tar.xz
+        sha256: c93e9852b7b2dc931197831438fee5295976ee0ba24f8524a8907be5c2ba5937
 
   # Flycast native dep
   - name: libminiupnpc

--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -62,7 +62,7 @@ modules:
   - name: compat
     buildsystem: simple
     build-commands:
-      - mkdir -p /app/lib/i386-linux-gnu /app/lib/debug/lib/i386-linux-gnu
+      - mkdir -p /app/lib/i386-linux-gnu
       - install -d /app/wine
 
   - name: fightcade

--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -22,7 +22,7 @@ add-extensions:
   org.freedesktop.Platform.GL32:
     directory: lib/i386-linux-gnu/GL
     version: '1.4'
-    versions: 21.08;1.4
+    versions: 22.08;1.4
     subdirectories: true
     no-autodownload: true
     autodelete: false

--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -1,8 +1,8 @@
 app-id: com.fightcade.Fightcade
 base: org.electronjs.Electron2.BaseApp
-base-version: '21.08'
+base-version: '22.08'
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 command: fightcade
 tags:
@@ -12,11 +12,11 @@ tags:
 add-extensions:
   org.freedesktop.Platform.Compat.i386:
     directory: lib/i386-linux-gnu
-    version: '21.08'
+    version: '22.08'
 
   org.freedesktop.Platform.Compat.i386.Debug:
     directory: lib/debug/lib/i386-linux-gnu
-    version: '21.08'
+    version: '22.08'
     no-autodownload: true
 
   org.freedesktop.Platform.GL32:

--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -14,11 +14,6 @@ add-extensions:
     directory: lib/i386-linux-gnu
     version: '22.08'
 
-  org.freedesktop.Platform.Compat.i386.Debug:
-    directory: lib/debug/lib/i386-linux-gnu
-    version: '22.08'
-    no-autodownload: true
-
   org.freedesktop.Platform.GL32:
     directory: lib/i386-linux-gnu/GL
     version: '1.4'


### PR DESCRIPTION
Attempting to resolve https://github.com/flathub/com.fightcade.Fightcade/issues/91#issuecomment-1359962133

It seems the Ubuntu 22 dependencies for Flycast were snuck into today's Fightcade update without warning, thus breaking compatibility with Flatpak's 21.08 runtimes. Last time I worked with blueminder to try to make the new Flycast run in the Flatpak some 22.08 runtimes were unavailable, hopefully they're ready to go now.