### PR TITLE
Downgrade Electron to 21.08

### DIFF
--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -1,6 +1,6 @@
 app-id: com.fightcade.Fightcade
 base: org.electronjs.Electron2.BaseApp
-base-version: '22.08'
+base-version: '21.08'
 runtime: org.freedesktop.Platform
 runtime-version: '22.08'
 sdk: org.freedesktop.Sdk


### PR DESCRIPTION
A few users are having issues starting the Fightcade frontend in 22.08.

`FATAL:gpu_data_manager_impl_private.cc(439)] GPU process isn't usable. Goodbye.`