### PR TITLE
Disable Electron sandbox

### DIFF
--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -56,6 +56,8 @@ finish-args:
   - --env=WINEDLLOVERRIDES=mscoree,mshtml=
   # Support 32-bit runtime
   - --env=LD_LIBRARY_PATH=/app/lib:/app/lib32
+  # Disable Zypak sandbox
+  - --env=ZYPAK_DISABLE_SANDBOX=1
 
 modules:
   # Create 32-bit and wine directories

--- a/scripts/fightcade-launcher.sh
+++ b/scripts/fightcade-launcher.sh
@@ -56,4 +56,4 @@ touch ${DATADIR}/logs/flycast.log
 cp -R /app/fightcade/Fightcade/emulator/flycast/data_orig/* ${DATADIR}/config/flycast/data
 
 # Boot Fightcade frontend
-/app/bin/zypak-wrapper /app/fightcade/Fightcade/fc2-electron/fc2-electron
+/app/bin/zypak-wrapper /app/fightcade/Fightcade/fc2-electron/fc2-electron --no-sandbox


### PR DESCRIPTION
Disable the Electron sandbox as it seems to be causing crashes for some Nvidia users.

Fightcade's use of electron is pretty minimal (limited to just the lobby frontend) so this shouldn't be a huge issue.