### PR TITLE
Update FBNeo training mode workaround

### DIFF
--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -112,8 +112,8 @@ modules:
       - rm -rf emulator/fbneo/config
       - ln -s /var/data/config/fcadefbneo emulator/fbneo/config
       # FBNeo training mode
-      - for game in emulator/fbneo/fbneo-training-mode/games/*; do ln -s /var/data/fbneo-training-mode-configs/${game##*/}.lua
-        ${game}/config.lua; done
+      - mv emulator/fbneo/fbneo-training-mode emulator/fbneo/fbneo-training-mode-original
+      - ln -s /var/data/fbneo-training-mode emulator/fbneo/fbneo-training-mode
       # FBNeo saved overlays
       - ln -s /var/data/config/fcadefbneo/fightcade emulator/fbneo/fightcade
       # Snes9x config

--- a/scripts/fightcade-launcher.sh
+++ b/scripts/fightcade-launcher.sh
@@ -30,11 +30,8 @@ mkdir -p ${DATADIR}/ROMs/flycast
 mkdir -p ${DATADIR}/config/fcadefbneo
 cp -n /app/fightcade/Fightcade/emulator/fbneo/config/fcadefbneo.default.ini ${DATADIR}/config/fcadefbneo/fcadefbneo.ini 2> /dev/null
 # FBNeo training mode
-mkdir -p ${DATADIR}/fbneo-training-mode-configs
-for game in /app/fightcade/Fightcade/emulator/fbneo/fbneo-training-mode/games/*
-do
-  touch ${DATADIR}/fbneo-training-mode-configs/${game##*/}.lua
-done
+mkdir -p ${DATADIR}/fbneo-training-mode
+cp -R /app/fightcade/Fightcade/emulator/fbneo/fbneo-training-mode-original/* ${DATADIR}/fbneo-training-mode/
 # FBNeo saved overlays
 mkdir -p ${DATADIR}/config/fcadefbneo/fightcade
 # Snes9x


### PR DESCRIPTION
Fightcade has changed how the fbneo-training-mode directory is laid out which breaks our older, more complex workaround. Switch to using a simpler symlink-based workaround.

Related to #95