### PR TITLE
wine: move to new prefix for wine 8

### DIFF
--- a/scripts/fightcade-launcher.sh
+++ b/scripts/fightcade-launcher.sh
@@ -9,7 +9,7 @@ DATADIR=/var/data
 echo "Creating or updating wine prefix (/var/data/winepfx), this may take a minute..."
 
 # Silently create/update Wine prefix
-WINEPREFIX=/var/data/winepfx WINEDEBUG=-all DISPLAY=:invalid wineboot -u
+WINEPREFIX=/var/data/winepfx-8 WINEDEBUG=-all DISPLAY=:invalid wineboot -u
 
 # Log file Fightcade expects to be able to write to
 mkdir -p /var/data/logs

--- a/scripts/wine.sh
+++ b/scripts/wine.sh
@@ -8,7 +8,7 @@ END
 )
 
 WINEPATH="/app/wine/bin/wine"
-export WINEPREFIX=/var/data/winepfx
+export WINEPREFIX=/var/data/winepfx-8
 
 if [[ -f ${WINEPATH} ]]; then
 	/app/wine/bin/wine "$@"


### PR DESCRIPTION
The old Wine 5 prefix seems to be invalid when upgraded to Wine 8, creating a new prefix at /var/data/winepfx-8 allows wine to launch normally.