### PR TITLE
Release version 2.3 of Fightcade Flatpak

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -29,6 +29,25 @@
   </screenshots>
   <releases>
     <release date="2022-03-27" version="2.2">
+      <p>FBNeo</p>
+      <ul>
+        <li>
+          Upgraded Wine to 8.0.1
+        </li>
+        <li>
+          Wine prefixes moved to data/wineprefixes/$(wine --version)
+        </li>
+        <li>
+          Added support for local save states
+        </li>
+        <li>
+          Improved training mode support
+        </li>
+        <li>
+          GPU sandbox disabled for better Nvidia compatibility (to avoid a crash at launch)
+        </li>
+    </release>
+    <release date="2023-07-05" version="2.3">
       <ul>
         <li>
           Added new Flycast dependencies to sandbox (Lua 5.3, libao)

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -46,6 +46,15 @@
         <li>
           GPU sandbox disabled for better Nvidia compatibility (to avoid a crash at launch)
         </li>
+        <li>
+          Support saved overlays
+        </li>
+      </ul>
+      <p>Flycast</p>
+      <ul>
+        <li>
+          Enable logging to a mutable copy of flycast.log
+        </li>
       </ul>
     </release>
     <release date="2022-03-27" version="2.2">

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -28,7 +28,7 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release date="2022-03-27" version="2.2">
+      <release date="2023-07-05" version="2.3">
       <p>FBNeo</p>
       <ul>
         <li>
@@ -48,7 +48,7 @@
         </li>
       </ul>
     </release>
-    <release date="2023-07-05" version="2.3">
+    <release date="2022-03-27" version="2.2">
       <ul>
         <li>
           Added new Flycast dependencies to sandbox (Lua 5.3, libao)

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -46,6 +46,7 @@
         <li>
           GPU sandbox disabled for better Nvidia compatibility (to avoid a crash at launch)
         </li>
+      </ul>
     </release>
     <release date="2023-07-05" version="2.3">
       <ul>


### PR DESCRIPTION
There's been enough major changes (including a Wine bump) to warrant a minor version upgrade of the Flatpak.