### PR TITLE
Change to Wayland by default

### DIFF
--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -40,7 +40,8 @@ sdk-extensions:
 
 finish-args:
   - --share=ipc
-  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
   - --share=network
   - --socket=pulseaudio
   - --allow=multiarch


### PR DESCRIPTION
Switch to using Wayland by default for Fightcade, offering X11 as a fallback.

While the current setup works fine in Gnome Wayland it seems to cause a regression in KDE Plasma.