### PR TITLE
flathub.json: remove flathubbot automerge

### DIFF
--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -232,6 +232,7 @@ modules:
   # Flycast native dep
   - name: libminiupnpc
     buildsystem: cmake-ninja
+    disable-http-decompression: true,
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
       - -DUPNPC_BUILD_SHARED=true

--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -248,7 +248,7 @@ modules:
       - install -m0644 -t /app/lib libminiupnpc.so
     sources:
       - type: archive
-        url: http://miniupnp.free.fr/files/miniupnpc-2.2.3.tar.gz
+        url: https://miniupnp.tuxfamily.org/files/miniupnpc-2.2.3.tar.gz
         sha256: dce41b4a4f08521c53a0ab163ad2007d18b5e1aa173ea5803bd47a1be3159c24
 
   # Wine dep. Should be moved to com.fightcade.Fightcade.Wine eventually.

--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,4 @@
 {
   "only-arches": ["x86_64"],
-  "automerge-flathubbot-prs": true,
   "publish-delay-hours": 0
 }

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -6,7 +6,7 @@
   <project_license>LicenseRef-proprietary</project_license>
   <name>Fightcade</name>
   <url type="homepage">https://www.fightcade.com/</url>
-  <summary>Play arcade games online.</summary>
+  <summary>Play arcade games online</summary>
   <description>
     <p>THE BEST WAY TO PLAY RETRO GAMES ONLINE</p>
     <p>Fightcade is a matchmaking platform for retro gaming, bundled with different emulators for seamless online play.</p>
@@ -28,90 +28,102 @@
     </screenshot>
   </screenshots>
   <releases>
-      <release date="2023-07-05" version="2.3">
-      <p>FBNeo</p>
-      <ul>
-        <li>
-          Upgraded Wine to 8.0.1
-        </li>
-        <li>
-          Wine prefixes moved to data/wineprefixes/$(wine --version)
-        </li>
-        <li>
-          Added support for local save states
-        </li>
-        <li>
-          Improved training mode support
-        </li>
-        <li>
-          GPU sandbox disabled for better Nvidia compatibility (to avoid a crash at launch)
-        </li>
-        <li>
-          Support saved overlays
-        </li>
-      </ul>
-      <p>Flycast</p>
-      <ul>
-        <li>
-          Enable logging to a mutable copy of flycast.log
-        </li>
-      </ul>
+    <release date="2023-07-05" version="2.3">
+      <description>
+        <p>FBNeo</p>
+        <ul>
+          <li>
+            Upgraded Wine to 8.0.1
+          </li>
+          <li>
+            Wine prefixes moved to data/wineprefixes/$(wine --version)
+          </li>
+          <li>
+            Added support for local save states
+          </li>
+          <li>
+            Improved training mode support
+          </li>
+          <li>
+            GPU sandbox disabled for better Nvidia compatibility (to avoid a crash at launch)
+          </li>
+          <li>
+            Support saved overlays
+          </li>
+        </ul>
+        <p>Flycast</p>
+        <ul>
+          <li>
+            Enable logging to a mutable copy of flycast.log
+          </li>
+        </ul>
+      </description>
     </release>
     <release date="2022-03-27" version="2.2">
-      <ul>
-        <li>
-          Added new Flycast dependencies to sandbox (Lua 5.3, libao)
-        </li>
-        <li>
-          Added symlinks for all JSON files to manifest (thanks @keenanweaver)
-        </li>
-        <li>
-          Wine prefix moved to /var/data/winepfx to avoid a clash when using --filesystem=home
-        </li>
-        <li>
-          Give permissions for org.freedesktop.ScreenSaver to allow correctly inhibiting screensaver during gameplay
-        </li>
-      </ul>
+      <description>
+        <ul>
+          <li>
+            Added new Flycast dependencies to sandbox (Lua 5.3, libao)
+          </li>
+          <li>
+            Added symlinks for all JSON files to manifest (thanks @keenanweaver)
+          </li>
+          <li>
+            Wine prefix moved to /var/data/winepfx to avoid a clash when using --filesystem=home
+          </li>
+          <li>
+            Give permissions for org.freedesktop.ScreenSaver to allow correctly inhibiting screensaver during gameplay
+          </li>
+        </ul>
+      </description>
     </release>
     <release date="2021-10-27" version="2.1">
-      <p>Flycast fixes</p>
-      <ul>
-        <li>
-          Flycast button mappings now properly persist between launches.
-        </li>
-      </ul>
+      <description>
+        <p>Flycast fixes</p>
+        <ul>
+          <li>
+            Flycast button mappings now properly persist between launches.
+          </li>
+        </ul>
+      </description>
     </release>
     <release date="2021-10-27" version="2.0">
-      <p>Wine Extension</p>
-      <ul>
-        <li>
-          Moves Wine into its own Flatpak (com.fightcade.Fightcade.Wine)
-        </li>
-      </ul>
+      <description>
+        <p>Wine Extension</p>
+        <ul>
+          <li>
+            Moves Wine into its own Flatpak (com.fightcade.Fightcade.Wine)
+          </li>
+        </ul>
+      </description>
     </release>
     <release date="2021-10-14" version="1.3">
-      <p>Flycast support and 21.08 deps</p>
-      <ul>
-        <li>
-          Added miniupnpc dependency for Flycast
-        </li>
-        <li>
-          Update Flatpak runtimes to 21.08
-        </li>
-      </ul>
+      <description>
+        <p>Flycast support and 21.08 deps</p>
+        <ul>
+          <li>
+            Added miniupnpc dependency for Flycast
+          </li>
+          <li>
+            Update Flatpak runtimes to 21.08
+          </li>
+        </ul>
+      </description>
     </release>
     <release date="2020-10-24" version="1.2"/>
     <release date="2020-10-04" version="1.1">
-      <p>Small improvements to Flatpak integration</p>
-      <ul>
-        <li>
-          Patches the Electron frontend to fix 'Open ROMs Dir'
-          <i>(Note: due to an upstream bug this doesn't work on xdg-desktop 1.8.0~1.8.2)</i>
-        </li>
-        <li>
-          Fix FBNeo configs not persisting between emulator sessions
-        </li>
-      </ul>
+      <description>
+        <p>Small improvements to Flatpak integration</p>
+        <ul>
+          <li>
+            Patches the Electron frontend to fix 'Open ROMs Dir'
+            (Note: due to an upstream bug this doesn't work on xdg-desktop 1.8.0~1.8.2)
+          </li>
+          <li>
+            Fix FBNeo configs not persisting between emulator sessions
+          </li>
+        </ul>
+      </description>
     </release>
     <release date="2020-09-20" version="1"/>
   </releases>


### PR DESCRIPTION
Removed Flathub bot automerge since it's no longer allowed: https://docs.flathub.org/docs/for-app-authors/linter/#flathub-json-automerge-enabled