### PR TITLE
flathub.json: re-enable flathubbot automerge

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,5 @@
 {
   "only-arches": ["x86_64"],
+  "automerge-flathubbot-prs": true,
   "publish-delay-hours": 0
 }


### PR DESCRIPTION
We were granted an exception in
https://github.com/flathub-infra/flatpak-builder-lint/pull/411 since the Fightcade client is functionally useless if it's out of date.

Re-enable the option to allow Flathubbot to automatically merge PRs when new Fightcade clients are published.