### PR TITLE
flycast: extract binary from AppImage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.flatpak-builder/

--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -67,6 +67,16 @@ modules:
       - mkdir -p /app/lib/i386-linux-gnu
       - install -d /app/wine
 
+  # For unbundling AppImage'd Flycast
+  - name: unappimage
+    buildsystem: simple
+    build-commands:
+      - make -C squashfs-tools -j ${FLATPAK_BUILDER_N_JOBS} install INSTALL_DIR=/app/bin
+    sources:
+      - type: git
+        url: https://github.com/refi64/unappimage
+        commit: d7f86f2a0d7ec3a69211125207d5f127386b849a
+
   - name: fightcade
     buildsystem: simple
     build-commands:
@@ -140,6 +150,12 @@ modules:
       - ln -s /var/data/config/flycast/data emulator/flycast/data
       # Wine wrapper
       - install -Dm755 wine.sh /app/fightcade/Resources/wine.sh
+      # Flycast binary
+      - unappimage emulator/flycast/flycast.elf
+      - rm emulator/flycast/flycast.elf
+      - install -Dm755 squashfs-root/usr/bin/flycast-dojo emulator/flycast/flycast.elf
+      - rm -rf squashfs-root
+      # Copy to /app/fightcade/Fightcade
       - cp -R * /app/fightcade/Fightcade
     sources:
       - type: archive

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -28,9 +28,14 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release date="2024-06-25" version="2.3.2">
+      <description>
+        <p>Add support for Flycast AppImage (fixes Flycast)</p>
+      </description>
+    </release>
     <release date="2024-06-20" version="2.3.1">
       <description>
-        Fightcade client upgraded to version 2.1.41
+        <p>Fightcade client upgraded to version 2.1.41</p>
       </description>
     </release>
     <release date="2023-07-05" version="2.3">


### PR DESCRIPTION
Flycast is now distributed as an AppImage by default in Fightcade. Install unappimage and use that to extract the flycast-dojo binary out of the AppImage.