### PR TITLE
Add a workaround for Steam Deck Gaming mode compat

### DIFF
--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -201,6 +201,15 @@ modules:
       - type: file
         path: metainfo.xml
 
+  # Workaround for Steam Deck gaming mode's xdg-open
+  - name: steamdeck-xdgopen
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 steamdeck-xdgopen.sh /app/bin/xdg-open
+    sources:
+      - type: file
+        path: scripts/steamdeck-xdgopen.sh
+
   # Flycast native dep
   - shared-modules/lua5.3/lua-5.3.5.json
 

--- a/scripts/steamdeck-xdgopen.sh
+++ b/scripts/steamdeck-xdgopen.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Shim script for xdg-open.
+# Required by Steam Deck Gaming mode, since xdg-open in gaming mode does not
+# recognize Flatpak URI associations (for fcade:// URLs.)
+
+# If executing an fcade:// URL, pass directly to fcade-quark
+if [[ "$1" == fcade://* ]]; then
+  /app/bin/fcade-quark "$@"
+  exit 0
+fi
+
+# Fallback to xdg-open if we don't catch any of the above cases.
+/usr/bin/xdg-open "$@"


### PR DESCRIPTION
Add a workaround to get Fightcade working properly in Steam Deck gaming mode.

Gaming mode does provide `xdg-open`, but for some reason it doesn't seem to work properly for URIs provided by Flatpaks. This commit adds a script that intercepts the `xdg-open` command and forwards any `fcade://` commands directly to `fcade-quark`.

Fixes #147