### PR TITLE
zypak: fix ReCaptcha

### DIFF
--- a/scripts/fightcade-launcher.sh
+++ b/scripts/fightcade-launcher.sh
@@ -61,4 +61,4 @@ touch ${DATADIR}/logs/flycast.log
 cp -R /app/fightcade/Fightcade/emulator/flycast/data_orig/* ${DATADIR}/config/flycast/data
 
 # Boot Fightcade frontend
-/app/bin/zypak-wrapper /app/fightcade/Fightcade/fc2-electron/fc2-electron --disable-gpu-sandbox
+/app/bin/zypak-wrapper /app/fightcade/Fightcade/fc2-electron/fc2-electron --disable-gpu-sandbox --no-sandbox


### PR DESCRIPTION
For some reason ReCaptcha needs Zypak to be run with --no-sandbox.

Fixes #123