### PR TITLE
Refactor extension handling, Wine configuration, add ip command from iproute2.

### DIFF
--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -172,6 +172,18 @@ modules:
       - type: file
         path: metainfo.xml
 
+  # Provide ip command, needed for Fightcade to determine connection type
+  - name: iproute2
+    buildsystem: autotools
+    make-install-args:
+      - PREFIX=${FLATPAK_DEST}
+      - SBINDIR=${FLATPAK_DEST}/bin
+      - CONFDIR=${FLATPAK_DEST}/etc/iproute2
+    sources:
+      - type: archive
+        url: https://mirrors.edge.kernel.org/pub/linux/utils/net/iproute2/iproute2-6.2.0.tar.xz
+        sha256: 4d72730200ec5b2aabaa1a2f20553c6748292f065d9a154c7d5e22559df9fd62
+
   # Electron wrapper, needed for Fightcade frontend
   - name: zypak
     sources:


### PR DESCRIPTION
This PR simplifies the extension management and removes deprecated configurations:

Key Changes:
- Replaced `add-extensions` with `inherit-extensions` for better Flatpak integration
- Removed the redundant `compat` module (handled by extensions)
- Added proper extension inheritance for:
  - 32-bit compatibility (org.freedesktop.Platform.Compat.i386)
  - 32-bit GL support (org.freedesktop.Platform.GL32)
  - Wine components (org.winehq.Wine.gecko/mono)
- Removed WINEDLLOVERRIDES env var (now handled by extensions)
- Added iproute2 module, provide ip command, lack of ip command makes user doesn't have network icon in Fightcade user list.
- Added symlinks for update logs