### PR TITLE
Inhibit screensaver during FBNeo gameplay (#76)

### DIFF
--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -132,6 +132,10 @@ modules:
       - ln -s /var/data/config/flycast/data emulator/flycast/data
       # Wine wrapper
       - install -Dm755 wine.sh /app/fightcade/Resources/wine.sh
+      # Screensaver-inhibiting launch wrapper (holds an org.freedesktop.ScreenSaver
+      # inhibit for the lifetime of the wrapped wine process)
+      - gcc -O2 -Wall launch-inhibit.c -o launch-inhibit $(pkg-config --cflags --libs gio-2.0)
+      - install -Dm755 launch-inhibit /app/fightcade/Resources/launch-inhibit
       # Flycast binary
       - unappimage emulator/flycast/flycast.elf
       - rm emulator/flycast/flycast.elf
@@ -150,6 +154,8 @@ modules:
           url-template: https://web.fightcade.com/download/Fightcade-linux-v${version}.tar.gz
       - type: file
         path: scripts/wine.sh
+      - type: file
+        path: scripts/launch-inhibit.c
 
   - name: fightcade-extra
     buildsystem: simple

--- a/scripts/launch-inhibit.c
+++ b/scripts/launch-inhibit.c
@@ -1,0 +1,95 @@
+/*
+ * launch-inhibit: run a command while holding an org.freedesktop.ScreenSaver
+ * inhibition for the whole lifetime of that command.
+ *
+ * A one-shot dbus-send/gdbus call is not enough: since GNOME 3.36 the inhibit
+ * is released as soon as the D-Bus connection that requested it closes. This
+ * helper keeps a single session-bus connection open until the wrapped command
+ * exits, so the screensaver stays inhibited for the entire session.
+ *
+ * The runtime's Python has no PyGObject, but the freedesktop Platform ships
+ * libgio, so this is implemented in C and compiled at build time against the
+ * SDK's gio-2.0.
+ *
+ * Usage: launch-inhibit <command> [args...]
+ *
+ * Inhibition is best-effort: if the session bus or the ScreenSaver interface
+ * is unavailable, the wrapped command is still run normally.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <gio/gio.h>
+
+#define APP_NAME "com.fightcade.Fightcade"
+#define REASON "Fightcade gameplay"
+#define SS_NAME "org.freedesktop.ScreenSaver"
+#define SS_PATH "/org/freedesktop/ScreenSaver"
+
+int main(int argc, char **argv) {
+    if (argc < 2) {
+        fprintf(stderr, "usage: %s <command> [args...]\n", argv[0]);
+        return 2;
+    }
+
+    GError *error = NULL;
+    GDBusConnection *conn = g_bus_get_sync(G_BUS_TYPE_SESSION, NULL, &error);
+    guint32 cookie = 0;
+    gboolean inhibited = FALSE;
+
+    if (conn == NULL) {
+        fprintf(stderr, "launch-inhibit: no session bus: %s\n",
+                error ? error->message : "unknown error");
+        g_clear_error(&error);
+    } else {
+        GVariant *reply = g_dbus_connection_call_sync(
+            conn, SS_NAME, SS_PATH, SS_NAME, "Inhibit",
+            g_variant_new("(ss)", APP_NAME, REASON), G_VARIANT_TYPE("(u)"),
+            G_DBUS_CALL_FLAGS_NONE, -1, NULL, &error);
+        if (reply == NULL) {
+            fprintf(stderr, "launch-inhibit: could not inhibit screensaver: %s\n",
+                    error ? error->message : "unknown error");
+            g_clear_error(&error);
+        } else {
+            g_variant_get(reply, "(u)", &cookie);
+            g_variant_unref(reply);
+            inhibited = TRUE;
+        }
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        perror("launch-inhibit: fork");
+        return 1;
+    }
+    if (pid == 0) {
+        execvp(argv[1], &argv[1]);
+        perror("launch-inhibit: execvp");
+        _exit(127);
+    }
+
+    int status = 0;
+    while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {
+        /* retry */
+    }
+
+    if (inhibited && conn != NULL) {
+        GVariant *r = g_dbus_connection_call_sync(
+            conn, SS_NAME, SS_PATH, SS_NAME, "UnInhibit",
+            g_variant_new("(u)", cookie), NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL,
+            &error);
+        if (r != NULL)
+            g_variant_unref(r);
+        g_clear_error(&error);
+    }
+
+    if (WIFEXITED(status))
+        return WEXITSTATUS(status);
+    if (WIFSIGNALED(status))
+        return 128 + WTERMSIG(status);
+    return 1;
+}

--- a/scripts/wine.sh
+++ b/scripts/wine.sh
@@ -11,7 +11,7 @@ WINEPATH="/app/bin/wine"
 . /app/bin/get-wine-prefix
 
 if [[ -f ${WINEPATH} ]]; then
-	/app/bin/wine "$@"
+	exec /app/fightcade/Resources/launch-inhibit /app/bin/wine "$@"
 else
 	zenity \
 	  --warning \


### PR DESCRIPTION
FBNeo made no attempt to inhibit the screensaver on Linux, so the screen could blank or lock during a match.

A one-shot dbus-send/gdbus call is not enough: since GNOME 3.36 the inhibit is released as soon as the D-Bus connection that requested it closes. Add launch-inhibit, a small helper that keeps a single org.freedesktop.ScreenSaver connection open for the entire lifetime of the wrapped process, and route wine.sh's wine exec through it.

The Platform runtime's Python has no PyGObject, but it does ship libgio, so the helper is written in C and compiled at build time against the SDK's gio-2.0. Inhibition is best-effort: if the session bus or the ScreenSaver interface is unavailable, wine still launches normally. The required --talk-name=org.freedesktop.ScreenSaver permission was already granted, so no manifest permission changes are needed.