### PR TITLE
Warn when a conflicting non-Flatpak install is present (#126)

### DIFF
--- a/com.fightcade.Fightcade.yml
+++ b/com.fightcade.Fightcade.yml
@@ -34,6 +34,10 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   # Needed for controller support
   - --device=all
+  # Read-only access to the host's default-applications list so we can warn the
+  # user when a conflicting non-Flatpak Fightcade install owns the fcade:// URL
+  # handler (see issue #126 and flathub-infra/flatpak-builder-lint#1081).
+  - --filesystem=xdg-config/mimeapps.list:ro
   # Add Steamos extension point to $PATH
   - --env=PATH=/app/bin:/usr/bin:/app/steamos/bin
   # Support 32-bit runtime

--- a/scripts/fightcade-launcher.sh
+++ b/scripts/fightcade-launcher.sh
@@ -2,6 +2,46 @@
 
 DATADIR=/var/data
 
+# Warn when a conflicting non-Flatpak ("desktop") Fightcade install currently
+# owns the fcade:// URL handler. When both are installed they fight over the
+# scheme and neither can reliably launch challenge URLs (see issue #126).
+#
+# The Flatpak's own handler is exported as com.fightcade.Fightcade.fcade-quark
+# .desktop; the desktop version registers a bare fcade-quark.desktop, so we
+# warn whenever the effective default is anything other than ours.
+#
+# NOTE: we read the host's default-applications list at $HOME/.config, NOT
+# $XDG_CONFIG_HOME. Inside the sandbox XDG_CONFIG_HOME is remapped to the app's
+# private config dir, whereas the host file is exposed at $HOME/.config/mimeapps
+# .list via the --filesystem=xdg-config/mimeapps.list:ro permission.
+MIMEAPPS="${HOME}/.config/mimeapps.list"
+OUR_HANDLER="com.fightcade.Fightcade.fcade-quark.desktop"
+
+if [ -f "${MIMEAPPS}" ]; then
+    handler=$(awk -F= -v k="x-scheme-handler/fcade" '
+        /^\[Default Applications\]/ { d=1; next }
+        /^\[/                       { d=0 }
+        d && $1==k                  { print $2; exit }
+    ' "${MIMEAPPS}")
+    handler=${handler%%;*}   # [Default Applications] may be a ;-separated list
+
+    # Only warn when the handler is set to something other than ours. An empty
+    # value means "no explicit default" — unknown, so we stay quiet rather than
+    # false-positive.
+    if [ -n "${handler}" ] && [ "${handler}" != "${OUR_HANDLER}" ]; then
+        zenity \
+          --warning \
+          --title "Conflicting Fightcade install detected" \
+          --ok-label "I Acknowledge" \
+          --text "A non-Flatpak installation of Fightcade currently handles fcade:// links on this system.
+
+Having both the desktop and Flatpak versions installed at once prevents the Fightcade Flatpak from launching challenge URLs correctly.
+
+Please remove one of the two installations. For instructions on removing the non-Flatpak version, see:
+<a href=\"https://github.com/flathub/com.fightcade.Fightcade#removing-other-fightcade-installs\">github.com/flathub/com.fightcade.Fightcade</a>"
+    fi
+fi
+
 . /app/bin/get-wine-prefix
 
 # Tell the user that the wine prefix may take some time to create.


### PR DESCRIPTION
When both the desktop and Flatpak versions of Fightcade are installed they contend over the fightcade:// URL handler and neither can reliably launch challenge URLs.

Detect the desktop version at startup by looking for its bare-named desktop entries (Fightcade.desktop / fcade-quark.desktop) and show a zenity warning if found. The Flatpak's own entries are prefixed com.fightcade.Fightcade.* so this never trips on itself.

This needs read access to the host's application entries, which the sandbox did not previously have, so add --filesystem=xdg-data/applications:ro. Note the detection deliberately uses $HOME/.local/share rather than $XDG_DATA_HOME: inside the sandbox XDG_DATA_HOME is remapped to the app's private data dir, while the host directory is exposed at $HOME/.local/share/applications by that permission.